### PR TITLE
Fix: Persist links data when navigating back in onboarding

### DIFF
--- a/app/(onboarding)/onboarding/links/page.tsx
+++ b/app/(onboarding)/onboarding/links/page.tsx
@@ -171,7 +171,6 @@ export default function LinksPage() {
       }
 
       toastSuccess("Links saved", "Your links have been saved successfully");
-      localStorage.removeItem("onboarding-links");
       window.dispatchEvent(new CustomEvent("onboarding-links-changed", {
         detail: { hasUnsavedLinks: false },
       }));

--- a/app/(onboarding)/onboarding/preview/preview-client.tsx
+++ b/app/(onboarding)/onboarding/preview/preview-client.tsx
@@ -18,6 +18,8 @@ export default function PreviewClient() {
 
       if (res.ok) {
         toastSuccess("Profile published", "Your profile is now live!");
+        localStorage.removeItem("onboarding-links");
+        localStorage.removeItem("onboarding-username");
         router.push("/dashboard");
       } else {
         const data = await res.json();


### PR DESCRIPTION
## Summary
Fixes #11

This PR addresses the issue where links data is lost when navigating back from the Preview step to the Links step during onboarding.

## Changes
- Removed the premature `localStorage.removeItem("onboarding-links")` call in `app/(onboarding)/onboarding/links/page.tsx`.
- Added cleanup logic to `app/(onboarding)/onboarding/preview/preview-client.tsx` to remove `onboarding-links` and `onboarding-username` only after successful profile publication.

## Impact
Users can now navigate back and forth between onboarding steps without losing their drafted links, providing a smoother user experience.